### PR TITLE
Add notifications context with background refresh

### DIFF
--- a/src/app/(sidebars)/(title)/notifications/page.tsx
+++ b/src/app/(sidebars)/(title)/notifications/page.tsx
@@ -1,8 +1,7 @@
-import { Feed } from "~/components/Feed";
-import { lensNotificationToNative } from "~/components/notifications/Notification";
-import { NotificationView } from "~/components/notifications/NotificationView";
-import { getServerAuth } from "~/utils/getServerAuth";
 import { fetchNotifications } from "@lens-protocol/client/actions";
+import { lensNotificationToNative } from "~/components/notifications/Notification";
+import { NotificationsPageClient } from "~/components/notifications/NotificationsPageClient";
+import { getServerAuth } from "~/utils/getServerAuth";
 
 const endpoint = "/api/notifications";
 
@@ -13,9 +12,7 @@ const notifications = async () => {
     throw new Error("Failed to get notifications (T T)");
   }
 
-  return (
-    <Feed ItemView={NotificationView} endpoint={endpoint} initialData={notifications} initialCursor={nextCursor} />
-  );
+  return <NotificationsPageClient endpoint={endpoint} initialData={notifications} initialCursor={nextCursor} />;
 };
 
 const getInitialFeed = async () => {
@@ -25,7 +22,7 @@ const getInitialFeed = async () => {
     // throw new Error("Unauthorized TT");
     return {
       notifications: [],
-      nextCursor: undefined
+      nextCursor: undefined,
     };
   }
 
@@ -36,7 +33,7 @@ const getInitialFeed = async () => {
         filter: {
           timeBasedAggregation: true,
           includeLowScore: false,
-        }
+        },
       });
 
       if (result.isErr()) {
@@ -47,17 +44,16 @@ const getInitialFeed = async () => {
 
       return {
         notifications,
-        nextCursor: result.value.pageInfo.next
+        nextCursor: result.value.pageInfo.next,
       };
-    } else {
-      throw new Error("Session client required for notifications");
     }
+    throw new Error("Session client required for notifications");
   } catch (error) {
     console.error("Error using fetchNotifications action:", error);
 
     // We no longer need the fallback since the client.notifications.fetch() method
     // is deprecated in the new API. Instead, we'll throw an error.
-    throw new Error("Failed to fetch notifications: " + (error.message || "Unknown error"));
+    throw new Error(`Failed to fetch notifications: ${error.message || "Unknown error"}`);
   }
 };
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import dynamic from "next/dynamic";
 import Script from "next/script";
 import { Providers } from "~/components/Providers";
+import { NotificationsProvider } from "~/components/notifications/NotificationsContext";
 import { Toaster } from "~/components/ui/sonner";
 import { UserProvider } from "~/components/user/UserContext";
 import { quicksand } from "~/styles/fonts";
@@ -29,12 +30,14 @@ export default async function RootLayout({ children }) {
       </head>
       <body className="flex flex-col relative">
         <Providers>
-          <UserProvider user={user}>
-            <AuthWatcher />
-            <Toaster position="top-right" offset={16} />
+          <NotificationsProvider>
+            <UserProvider user={user}>
+              <AuthWatcher />
+              <Toaster position="top-right" offset={16} />
 
-            {children}
-          </UserProvider>
+              {children}
+            </UserProvider>
+          </NotificationsProvider>
         </Providers>
       </body>
     </html>

--- a/src/components/menu/Menu.tsx
+++ b/src/components/menu/Menu.tsx
@@ -1,6 +1,6 @@
+import { fetchAccount } from "@lens-protocol/client/actions";
 import {
   AtSign,
-  BellIcon,
   BookmarkIcon,
   GavelIcon,
   GlobeIcon,
@@ -12,7 +12,6 @@ import {
 } from "lucide-react";
 import Link from "~/components/Link";
 import { Button } from "~/components/ui/button";
-import { fetchAccount } from "@lens-protocol/client/actions";
 import { getServerAuth } from "~/utils/getServerAuth";
 import { ServerSignedIn } from "../auth/ServerSignedIn";
 import PostWizard from "../post/PostWizard";
@@ -21,6 +20,7 @@ import type { User } from "../user/User";
 import { lensAcountToUser } from "../user/User";
 import { UserAvatar } from "../user/UserAvatar";
 import { ConnectWalletButton } from "../web3/WalletButtons";
+import { NotificationButton } from "./NotificationButton";
 import { SearchButton } from "./Search";
 
 export default async function Menu() {
@@ -70,12 +70,7 @@ export const MenuAuthed = ({ handle, user }: { handle: string; user: User }) => 
         </Button>
       </Link> */}
 
-
-      <Link href="/notifications">
-        <Button variant="ghost" size="icon" className="w-10 h-10">
-          <BellIcon size={20} strokeWidth={2.5} />
-        </Button>
-      </Link>
+      <NotificationButton />
 
       <Dialog>
         <DialogTrigger asChild>
@@ -98,7 +93,6 @@ export const MenuAuthed = ({ handle, user }: { handle: string; user: User }) => 
           <BookmarkIcon size={20} strokeWidth={2.5} />
         </Button>
       </Link>
-
     </>
   );
 };

--- a/src/components/menu/NotificationButton.tsx
+++ b/src/components/menu/NotificationButton.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { BellIcon } from "lucide-react";
+import Link from "~/components/Link";
+import { useNotifications } from "~/components/notifications/NotificationsContext";
+import { Button } from "~/components/ui/button";
+
+export const NotificationButton = () => {
+  const { newCount } = useNotifications();
+
+  return (
+    <Link href="/notifications">
+      <Button variant="ghost" size="icon" className="w-10 h-10 relative">
+        <BellIcon size={20} strokeWidth={2.5} />
+        {newCount > 0 && (
+          <span className="absolute -bottom-1 -right-1 w-4 h-4 rounded-full bg-destructive text-destructive-foreground text-[10px] flex items-center justify-center">
+            {newCount}
+          </span>
+        )}
+      </Button>
+    </Link>
+  );
+};

--- a/src/components/notifications/Notification.ts
+++ b/src/components/notifications/Notification.ts
@@ -1,8 +1,8 @@
-import type { Account, Notification as LensNotification } from "@lens-protocol/client";
+import type { Notification as LensNotification } from "@lens-protocol/client";
 import { type Post, lensItemToPost } from "../post/Post";
 import { type User, lensAcountToUser } from "../user/User";
 
-type NotificationType = "Reaction" | "Comment" | "Follow" | "Repost" | "Action" | "Mention" | "Quote";
+export type NotificationType = "Reaction" | "Comment" | "Follow" | "Repost" | "Action" | "Mention" | "Quote";
 
 export type Notification = {
   __typename: "Notification";
@@ -15,79 +15,78 @@ export type Notification = {
 };
 
 export function lensNotificationToNative(item: LensNotification): Notification {
-  let profiles: Account[] = [];
-  let actedOn: any;
-  let createdAt: string;
-  let type: NotificationType;
-  let reactionType: "Upvote" | "Downvote";
-  let id: string;
+  const base = { id: item.id };
 
-  // Handle different notification types in Lens v3
   switch (item.__typename) {
     case "CommentNotification":
-      id = item.id;
-      profiles = [item.comment.author];
-      actedOn = item.comment;
-      createdAt = item.comment.timestamp;
-      type = "Comment";
-      break;
-    case "ReactionNotification":
-      id = item.id;
-      profiles = item.reactions.map((reaction) => reaction.account);
-      actedOn = item.post || item.post;
-      createdAt = item.reactions[0]?.reactions[0].reactedAt || new Date().toISOString();
-      type = "Reaction";
-      // Handle different reaction formats
-      const reactionValue = item.reactions[0]?.reactions[0].reaction;
-      reactionType = reactionValue === "UPVOTE" ? "Upvote" : "Downvote";
-      break;
+      return {
+        ...base,
+        who: [lensAcountToUser(item.comment.author)],
+        actedOn: lensItemToPost(item.comment) || undefined,
+        createdAt: new Date(item.comment.timestamp),
+        type: "Comment",
+        __typename: "Notification",
+      };
+
+    case "ReactionNotification": {
+      const reaction = item.reactions[0]?.reactions[0];
+      return {
+        ...base,
+        who: item.reactions.map((r) => lensAcountToUser(r.account)),
+        actedOn: item.post ? lensItemToPost(item.post) || undefined : undefined,
+        createdAt: new Date(reaction?.reactedAt ?? Date.now()),
+        type: "Reaction",
+        reactionType: reaction?.reaction === "UPVOTE" ? "Upvote" : "Downvote",
+        __typename: "Notification",
+      };
+    }
+
     case "FollowNotification":
-      id = item.id;
-      profiles = item.followers.map((follower) => follower.account);
-      actedOn = undefined;
-      createdAt = item.followers[0].followedAt || new Date().toISOString();
-      type = "Follow";
-      break;
+      return {
+        ...base,
+        who: item.followers.map((f) => lensAcountToUser(f.account)),
+        createdAt: new Date(item.followers[0]?.followedAt ?? Date.now()),
+        type: "Follow",
+        __typename: "Notification",
+      };
+
     case "MentionNotification":
-      id = item.id;
-      profiles = [item.post?.author || item.post?.author];
-      actedOn = item.post || item.post;
-      createdAt = (item.post || item.post)?.timestamp || new Date().toISOString();
-      type = "Mention";
-      break;
+      return {
+        ...base,
+        who: [lensAcountToUser(item.post.author)],
+        actedOn: item.post ? lensItemToPost(item.post) || undefined : undefined,
+        createdAt: new Date(item.post.timestamp),
+        type: "Mention",
+        __typename: "Notification",
+      };
+
     case "RepostNotification":
-      id = item.id;
-      profiles = item.reposts?.map((repost) => repost.account) ||
-        [item.reposts[0]?.account || item.reposts[0]?.account];
-      actedOn = item.post || item.post;
-      createdAt = (item.post || item.post)?.timestamp || new Date().toISOString();
-      type = "Repost";
-      break;
+      return {
+        ...base,
+        who: item.reposts.map((r) => lensAcountToUser(r.account)),
+        actedOn: item.post ? lensItemToPost(item.post) || undefined : undefined,
+        createdAt: new Date(item.post.timestamp),
+        type: "Repost",
+        __typename: "Notification",
+      };
+
     case "QuoteNotification":
-      id = item.id;
-      profiles = [item.quote?.author];
-      actedOn = item.quote || item.quote;
-      createdAt = item.quote?.timestamp || new Date().toISOString();
-      type = "Quote";
-      break;
+      return {
+        ...base,
+        who: [lensAcountToUser(item.quote.author)],
+        actedOn: item.quote ? lensItemToPost(item.quote) || undefined : undefined,
+        createdAt: new Date(item.quote.timestamp),
+        type: "Quote",
+        __typename: "Notification",
+      };
+
     default:
-      profiles = [];
-      actedOn = undefined;
-      createdAt = new Date().toISOString();
-      type = "Action";
-      break;
+      return {
+        ...base,
+        who: [],
+        createdAt: new Date(),
+        type: "Action",
+        __typename: "Notification",
+      };
   }
-
-  const who = profiles.map(lensAcountToUser);
-  const content = actedOn ? lensItemToPost(actedOn) : undefined;
-
-  return {
-    id,
-    who,
-    type,
-    actedOn: content,
-    reactionType: reactionType,
-    createdAt: new Date(createdAt || Date.now()),
-    __typename: "Notification",
-  };
 }

--- a/src/components/notifications/NotificationView.tsx
+++ b/src/components/notifications/NotificationView.tsx
@@ -15,7 +15,7 @@ import { Card, CardContent } from "../ui/card";
 import { UserAvatarArray } from "../user/UserAvatar";
 import type { Notification } from "./Notification";
 
-export const NotificationView = ({ item }: { item: Notification }) => {
+export const NotificationView = ({ item, highlight = false }: { item: Notification; highlight?: boolean }) => {
   const post = (
     <Link className="hover:underline" href={`/p/${item?.actedOn?.id}`}>
       post
@@ -60,7 +60,7 @@ export const NotificationView = ({ item }: { item: Notification }) => {
   const content = item?.actedOn?.metadata && "content" in item.actedOn.metadata ? item?.actedOn?.metadata?.content : "";
 
   return (
-    <Card>
+    <Card className={highlight ? "bg-accent/20" : undefined}>
       <CardContent className="flex h-fit w-full flex-row gap-4 p-2 sm:p-4">
         <div className="shrink-0 grow-0 rounded-full">
           <UserAvatarArray users={users} amountTruncated={wasTruncated ? amountTruncated : undefined} />

--- a/src/components/notifications/NotificationsContext.tsx
+++ b/src/components/notifications/NotificationsContext.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { type ReactNode, createContext, useContext, useEffect, useState } from "react";
+import type { Notification } from "./Notification";
+
+interface NotificationsContextValue {
+  notifications: Notification[];
+  lastSeen: number;
+  newCount: number;
+  highlightIds: string[];
+  setNotifications: (items: Notification[]) => void;
+  markAllAsRead: () => void;
+}
+
+const NotificationsContext = createContext<NotificationsContextValue | undefined>(undefined);
+
+function parseNotification(raw: any): Notification {
+  return {
+    ...raw,
+    createdAt: new Date(raw.createdAt),
+    actedOn: raw.actedOn
+      ? {
+          ...raw.actedOn,
+          createdAt: new Date(raw.actedOn.createdAt),
+          updatedAt: raw.actedOn.updatedAt ? new Date(raw.actedOn.updatedAt) : undefined,
+        }
+      : undefined,
+  } as Notification;
+}
+
+export function NotificationsProvider({ children }: { children: ReactNode }) {
+  const [notifications, setNotificationsState] = useState<Notification[]>([]);
+  const [lastSeen, setLastSeen] = useState<number>(() => {
+    if (typeof window === "undefined") return Date.now();
+    const stored = window.localStorage.getItem("lastSeenNotifications");
+    return stored ? Number.parseInt(stored, 10) : Date.now();
+  });
+  const [highlightIds, setHighlightIds] = useState<string[]>([]);
+  const [newCount, setNewCount] = useState<number>(0);
+
+  const computeNewCount = (items: Notification[]) =>
+    items.filter((n) => new Date(n.createdAt).getTime() > lastSeen).length;
+
+  const setNotifications = (items: Notification[]) => {
+    const parsed = items.map((n) => (typeof n.createdAt === "string" ? parseNotification(n) : n));
+    setNotificationsState(parsed);
+    setNewCount(computeNewCount(parsed));
+  };
+
+  const refresh = async () => {
+    try {
+      const res = await fetch("/api/notifications");
+      if (!res.ok) return;
+      const data = await res.json();
+      if (Array.isArray(data.data)) {
+        setNotifications(data.data);
+      }
+    } catch (err) {
+      console.error("Failed to fetch notifications", err);
+    }
+  };
+
+  useEffect(() => {
+    refresh();
+    const interval = setInterval(refresh, 30_000);
+    return () => clearInterval(interval);
+  }, [lastSeen]);
+
+  const markAllAsRead = () => {
+    const now = Date.now();
+    const newIds = notifications.filter((n) => new Date(n.createdAt).getTime() > lastSeen).map((n) => n.id);
+    setHighlightIds(newIds);
+    setNewCount(0);
+    setLastSeen(now);
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem("lastSeenNotifications", now.toString());
+    }
+    setTimeout(() => setHighlightIds([]), 300);
+  };
+
+  return (
+    <NotificationsContext.Provider
+      value={{ notifications, lastSeen, newCount, highlightIds, setNotifications, markAllAsRead }}
+    >
+      {children}
+    </NotificationsContext.Provider>
+  );
+}
+
+export function useNotifications() {
+  const ctx = useContext(NotificationsContext);
+  if (!ctx) throw new Error("useNotifications must be used within NotificationsProvider");
+  return ctx;
+}

--- a/src/components/notifications/NotificationsPageClient.tsx
+++ b/src/components/notifications/NotificationsPageClient.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useEffect } from "react";
+import { Feed } from "../Feed";
+import type { Notification } from "./Notification";
+import { NotificationView } from "./NotificationView";
+import { useNotifications } from "./NotificationsContext";
+
+export const NotificationsPageClient = ({
+  initialData,
+  initialCursor,
+  endpoint,
+}: {
+  initialData: Notification[];
+  initialCursor: string | undefined;
+  endpoint: string;
+}) => {
+  const { markAllAsRead, highlightIds, setNotifications } = useNotifications();
+
+  useEffect(() => {
+    setNotifications(initialData);
+    markAllAsRead();
+  }, []);
+
+  return (
+    <Feed
+      ItemView={({ item }: { item: Notification }) => (
+        <NotificationView item={item} highlight={highlightIds.includes(item.id)} />
+      )}
+      endpoint={endpoint}
+      initialData={initialData}
+      initialCursor={initialCursor}
+    />
+  );
+};


### PR DESCRIPTION
## Summary
- add `NotificationsProvider` for global state and last seen timestamp
- background fetch notifications every 30s
- add `NotificationButton` showing unread count
- highlight new notifications and clear highlight after marking read
- integrate provider in layout and page logic
- refactor notification conversion

## Testing
- `npx @biomejs/biome check src/app/layout.tsx 'src/app/(sidebars)/(title)/notifications/page.tsx' src/components/menu/Menu.tsx src/components/notifications/Notification.ts src/components/notifications/NotificationView.tsx src/components/menu/NotificationButton.tsx src/components/notifications/NotificationsContext.tsx src/components/notifications/NotificationsPageClient.tsx`