### PR TITLE
Improve Markdown link parsing

### DIFF
--- a/src/app/(sidebars)/p/[slug]/page.tsx
+++ b/src/app/(sidebars)/p/[slug]/page.tsx
@@ -48,6 +48,7 @@ const post = async ({ params }: { params: { slug: string } }) => {
 
 
   if (!lensPost) throw new Error("(╥_╥) Post not found");
+  console.log(lensPost);
 
   const lensComments = await fetchPostReferences(client, {
     referenceTypes: [PostReferenceType.CommentOn],

--- a/src/utils/parseContent.ts
+++ b/src/utils/parseContent.ts
@@ -23,10 +23,11 @@ class ContentParser {
   }
 
   parseLinks(): ContentParser {
-    const linkRegex = /(https?:\/\/\S+)/gi;
-    this.content = this.content.replace(linkRegex, (match) => {
-      const linkWithoutProtocol = match.replace(/^https?:\/\//, "");
-      return `[${linkWithoutProtocol}](${match})`;
+    const linkRegex = /<?((?:https?:\/\/|www\.)?[\w.-]+\.[^\s<>]+)>?/gi;
+    this.content = this.content.replace(linkRegex, (_match, link) => {
+      const url = link.startsWith("http") ? link : `https://${link}`;
+      const linkWithoutProtocol = link.replace(/^https?:\/\//, "");
+      return `[${linkWithoutProtocol}](${url})`;
     });
     return this;
   }

--- a/src/utils/parseContent.ts
+++ b/src/utils/parseContent.ts
@@ -23,8 +23,8 @@ class ContentParser {
   }
 
   parseLinks(): ContentParser {
-    const linkRegex = /<?((?:https?:\/\/|www\.)?[\w.-]+\.[^\s<>]+)>?/gi;
-    this.content = this.content.replace(linkRegex, (_match, link) => {
+    const linkRegex = /<?((?:https?:\/\/|www\.)?[\w-]+(?:\.[\w-]+)*\.[a-zA-Z]{2,}(?:\/[^\s<>]*)?)>?/gi;
+    this.content = this.content.replace(linkRegex, (match, link) => {
       const url = link.startsWith("http") ? link : `https://${link}`;
       const linkWithoutProtocol = link.replace(/^https?:\/\//, "");
       return `[${linkWithoutProtocol}](${url})`;


### PR DESCRIPTION
## Summary
- broaden regex to detect links without protocols and around angle brackets

## Testing
- `npx @biomejs/biome check --apply-unsafe src/utils/parseContent.ts`
- `npm run build` *(fails: connect EHOSTUNREACH to fonts.googleapis.com)*