### PR TITLE
Add address filtering and post type support

### DIFF
--- a/src/app/(sidebars)/u/[user]/all/page.tsx
+++ b/src/app/(sidebars)/u/[user]/all/page.tsx
@@ -50,9 +50,9 @@ const getInitialData = async (handle: string) => {
     };
   }
 
-  const posts = lensPosts.value.items.map(lensItemToPost);
+  const posts = lensPosts.items.map(lensItemToPost);
 
-  return { user, posts, nextCursor: lensPosts.value.pageInfo.next };
+  return { user, posts, nextCursor: lensPosts.pageInfo.next };
 };
 
 export default user;

--- a/src/app/(sidebars)/u/[user]/all/page.tsx
+++ b/src/app/(sidebars)/u/[user]/all/page.tsx
@@ -21,7 +21,12 @@ const user = async ({ params }: { params: { user: string } }) => {
   const { user, posts, nextCursor } = await getInitialData(handle);
 
   return (
-    <Feed ItemView={PostView} endpoint={`/api/posts?id=${user.id}`} initialData={posts} initialCursor={nextCursor} />
+    <Feed
+      ItemView={PostView}
+      endpoint={`/api/posts?address=${user.address}&type=all`}
+      initialData={posts}
+      initialCursor={nextCursor}
+    />
   );
 };
 

--- a/src/app/(sidebars)/u/[user]/comments/page.tsx
+++ b/src/app/(sidebars)/u/[user]/comments/page.tsx
@@ -50,9 +50,9 @@ const getInitialData = async (handle: string) => {
     };
   }
 
-  const posts = lensPosts.value.items.map(lensItemToPost);
+  const posts = lensPosts.items.map(lensItemToPost);
 
-  return { user, posts, nextCursor: lensPosts.value.pageInfo.next };
+  return { user, posts, nextCursor: lensPosts.pageInfo.next };
 };
 
 export default user;

--- a/src/app/(sidebars)/u/[user]/comments/page.tsx
+++ b/src/app/(sidebars)/u/[user]/comments/page.tsx
@@ -23,7 +23,7 @@ const user = async ({ params }: { params: { user: string } }) => {
   return (
     <Feed
       ItemView={PostView}
-      endpoint={`/api/posts?id=${user.id}&type=comment`}
+      endpoint={`/api/posts?address=${user.address}&type=comment`}
       initialData={posts}
       initialCursor={nextCursor}
     />

--- a/src/app/(sidebars)/u/[user]/page.tsx
+++ b/src/app/(sidebars)/u/[user]/page.tsx
@@ -26,7 +26,7 @@ const user = async ({ params }: { params: { user: string } }) => {
   return (
     <Feed
       ItemView={PostView}
-      endpoint={`/api/posts?id=${user.id}&type=post`}
+      endpoint={`/api/posts?address=${user.address}&type=post`}
       initialData={posts}
       initialCursor={nextCursor}
     />
@@ -43,7 +43,7 @@ const getInitialData = async (username: string) => {
 
   const result = await fetchPosts(client, {
     filter: {
-      authors: [user.id],
+      authors: [user.address],
       postTypes: [PostType.Root],
     },
   });

--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -11,15 +11,36 @@ export async function GET(req: NextRequest) {
   const { searchParams } = req.nextUrl;
   const cursor = searchParams.get("cursor") || undefined;
   const type = searchParams.get("type") || "post";
+  const address = searchParams.get("address") || undefined;
 
   try {
     const { client, sessionClient, isAuthenticated, profileId } = await getServerAuth();
 
+    let postTypes: PostType[];
+
+    switch (type) {
+      case "comment":
+        postTypes = [PostType.Comment];
+        break;
+      case "repost":
+        postTypes = [PostType.Repost];
+        break;
+      case "all":
+        postTypes = [PostType.Root, PostType.Comment, PostType.Repost];
+        break;
+      default:
+        postTypes = [PostType.Root];
+    }
+
+    const filter: any = { postTypes };
+    if (address) {
+      filter.authors = [address];
+    } else {
+      filter.feeds = [{ globalFeed: true }];
+    }
+
     const data = await fetchPosts(client, {
-      filter: {
-        postTypes: [PostType.Root],
-        feeds: [{ globalFeed: true }],
-      },
+      filter,
       cursor,
       pageSize: PageSize.Ten,
     });

--- a/src/components/post/Post.ts
+++ b/src/components/post/Post.ts
@@ -93,11 +93,11 @@ function getReactions(post: LensPost): Partial<PostReactions> {
     canDecrypt: false,
     totalReactions:
       post.stats?.upvotes +
-        post.stats?.downvotes +
-        post.stats?.bookmarks +
-        post.stats?.collects +
-        post.stats?.comments +
-        post.stats?.reposts || 0,
+      post.stats?.downvotes +
+      post.stats?.bookmarks +
+      post.stats?.collects +
+      post.stats?.comments +
+      post.stats?.reposts || 0,
   };
 }
 
@@ -129,37 +129,15 @@ function processComment(comment: any) {
   };
 }
 
-function getReplyFromItem(origin: any) {
+function getReplyFromItem(origin: LensPost) {
   if (!origin) return undefined;
 
-  if (origin.__typename === "Comment" && origin.commentOn) {
-    return {
-      id: origin.commentOn.slug ?? origin.commentOn.id,
-      author: origin.commentOn.by ? lensAcountToUser(origin.commentOn.by) : undefined,
-      content: origin.commentOn.metadata?.content || "",
-      metadata: origin.commentOn.metadata,
-      createdAt: new Date(origin.commentOn.createdAt || Date.now()),
-      updatedAt: new Date(origin.commentOn.createdAt || Date.now()),
-      reactions: undefined,
-      platform: "lens",
-      comments: [],
-      __typename: "Post" as const,
-    } as Post;
+  if (origin.__typename === "Post" && origin.commentOn) {
+    return lensItemToPost(origin.commentOn);
   }
 
-  if (origin.__typename === "Quote" && origin.quoteOn) {
-    return {
-      id: origin.quoteOn.slug ?? origin.quoteOn.id,
-      author: origin.quoteOn.by ? lensAcountToUser(origin.quoteOn.by) : undefined,
-      content: origin.quoteOn.metadata?.content || "",
-      metadata: origin.quoteOn.metadata,
-      createdAt: new Date(origin.quoteOn.createdAt || Date.now()),
-      updatedAt: new Date(origin.quoteOn.createdAt || Date.now()),
-      reactions: undefined,
-      platform: "lens",
-      comments: [],
-      __typename: "Post" as const,
-    } as Post;
+  if (origin.__typename === "Post" && origin.quoteOf) {
+    return lensItemToPost(origin.quoteOf);
   }
 
   return undefined;


### PR DESCRIPTION
## Summary
- allow `/api/posts` to filter by author address and post types
- pass `address` query parameter on user pages
- use `PostType` filters when fetching user posts

## Testing
- `npx @biomejs/biome check --apply-unsafe src/app/api/posts/route.ts src/app/'(sidebars)'/u/'[user]'/page.tsx src/app/'(sidebars)'/u/'[user]'/all/page.tsx src/app/'(sidebars)'/u/'[user]'/comments/page.tsx`
- `npm run check` *(fails: some repo-wide lint errors)*