### PR TITLE
Fetch and display user stats separately

### DIFF
--- a/src/app/(sidebars)/u/[user]/layout.tsx
+++ b/src/app/(sidebars)/u/[user]/layout.tsx
@@ -1,7 +1,9 @@
+import { fetchAccountStats } from "@lens-protocol/client/actions";
 import { notFound } from "next/navigation";
 import { Card } from "~/components/ui/card";
 import { UserNavigation } from "~/components/user/UserNavigation";
 import { UserProfile } from "~/components/user/UserProfile";
+import { getServerAuth } from "~/utils/getServerAuth";
 import { getUserByUsername } from "~/utils/getUserByHandle";
 
 export const maxDuration = 60;
@@ -20,9 +22,12 @@ export default async function layout({
 
   if (!user) return notFound();
 
+  const { client } = await getServerAuth();
+  const stats = await fetchAccountStats(client, { account: user.address }).unwrapOr(null);
+
   return (
     <>
-      <UserProfile user={user} />
+      <UserProfile user={user} stats={stats} />
       <UserNavigation handle={handle} />
 
       <Card className="z-[30] hover:bg-card p-4 border-0">{children}</Card>

--- a/src/components/user/User.ts
+++ b/src/components/user/User.ts
@@ -6,16 +6,6 @@ export type UserInterests = {
   label: string;
 };
 
-export type UserStats = {
-  followers: number;
-  following: number;
-  downvotes: number;
-  upvotes: number;
-  comments: number;
-  posts: number;
-  score: number;
-};
-
 export type UserActions = {
   followed: boolean;
   following: boolean;
@@ -25,7 +15,6 @@ export type UserActions = {
 export type User = {
   id: string;
   name?: string;
-  stats: UserStats;
   handle: string;
   address: string;
   namespace: string;
@@ -40,17 +29,6 @@ export function lensAcountToUser(account: Account): User {
   if (!account) return {} as unknown as User;
 
   const imageUrl = account?.metadata?.picture;
-
-  //// FIXME: Temporary stats
-  const stats = {
-    followers: 0,
-    following: 0,
-    downvotes: 0,
-    upvotes: 0,
-    comments: 0,
-    posts: 0,
-    score: 0,
-  };
 
   //// FIXME: Temporary interests
   const interests = [];
@@ -72,7 +50,6 @@ export function lensAcountToUser(account: Account): User {
     name: account?.metadata?.name,
     handle: account.username?.localName,
     namespace: account.username?.namespace?.address,
-    stats,
   };
 }
 

--- a/src/components/user/UserProfile.tsx
+++ b/src/components/user/UserProfile.tsx
@@ -1,3 +1,4 @@
+import type { AccountStats } from "@lens-protocol/client";
 import { CalendarIcon, EditIcon, MessageCircleIcon, User2Icon } from "lucide-react";
 import { notFound } from "next/navigation";
 import Link from "~/components/Link";
@@ -14,12 +15,21 @@ import { Separator } from "../ui/separator";
 import { type User } from "./User";
 import { UserView } from "./UserView";
 
-export const UserProfile = async ({ user }: { user?: User }) => {
+export const UserProfile = async ({
+  user,
+  stats,
+}: {
+  user?: User;
+  stats?: AccountStats | null;
+}) => {
   if (!user) return notFound();
 
   const { user: authedUser } = await getServerAuth();
   const isUserProfile = user.id === authedUser?.id;
   const isFollowingMe = user.actions.following;
+  const postsCount = (stats?.feedStats.posts ?? 0) + (stats?.feedStats.comments ?? 0);
+  const followingCount = stats?.graphFollowStats.following ?? 0;
+  const followersCount = stats?.graphFollowStats.followers ?? 0;
 
   return (
     <div className="p-4 z-20 flex w-full flex-row gap-4 bg-card drop-shadow-md rounded-b-2xl">
@@ -52,17 +62,17 @@ export const UserProfile = async ({ user }: { user?: User }) => {
         </div>
         <div className="text-sm flex flex-row gap-1 place-items-center">
           <MessageCircleIcon size={14} />
-          {user.stats.posts + user.stats.comments} Posts
+          {postsCount} Posts
         </div>
         <div className="text-sm flex flex-row gap-1 place-items-center">
           <User2Icon size={14} />
           <Dialog>
             <DialogTrigger>
-              Following <b>{user.stats.following}</b>
+              Following <b>{followingCount}</b>
             </DialogTrigger>
             <DialogContent className="max-w-96">
               <DialogTitle className="text-lg font-bold">
-                {user.handle}'s follows ({user.stats.following})
+                {user.handle}'s follows ({followingCount})
               </DialogTitle>
               <ScrollArea className="max-h-96">
                 <Feed
@@ -76,11 +86,11 @@ export const UserProfile = async ({ user }: { user?: User }) => {
           </Dialog>
           <Dialog>
             <DialogTrigger>
-              Followers <b>{user.stats.followers}</b>
+              Followers <b>{followersCount}</b>
             </DialogTrigger>
             <DialogContent className="max-w-96">
               <DialogTitle className="text-lg font-bold">
-                {user.handle}'s followers ({user.stats.followers})
+                {user.handle}'s followers ({followersCount})
               </DialogTitle>
               <ScrollArea className="max-h-96">
                 <Feed


### PR DESCRIPTION
## Summary
- remove `stats` from `User` type
- adjust `lensAcountToUser` to no longer include stats
- update `UserProfile` to receive stats separately
- fetch account stats in user layout and pass down

## Testing
- `npx biome check src/app/'(sidebars)'/u/'[user]'/layout.tsx src/components/user/User.ts src/components/user/UserProfile.tsx`
- `npm run check` *(fails: lint errors in unchanged files)*