### PR TITLE
Add OG metadata for pages

### DIFF
--- a/src/app/(centered)/policy/page.tsx
+++ b/src/app/(centered)/policy/page.tsx
@@ -1,3 +1,21 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy",
+  description: "Pingpad privacy policy",
+  openGraph: {
+    title: "Privacy Policy",
+    description: "Pingpad privacy policy",
+    images: [
+      {
+        url: "/logo.png",
+        width: 1200,
+        height: 630,
+      },
+    ],
+  },
+};
+
 const PolicyPage = () => {
   return (
     <>

--- a/src/app/(centered)/tos/page.tsx
+++ b/src/app/(centered)/tos/page.tsx
@@ -1,3 +1,21 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Terms of Service",
+  description: "Pingpad terms of service",
+  openGraph: {
+    title: "Terms of Service",
+    description: "Pingpad terms of service",
+    images: [
+      {
+        url: "/logo.png",
+        width: 1200,
+        height: 630,
+      },
+    ],
+  },
+};
+
 const ConditionsPage = () => {
   return (
     <>

--- a/src/app/(sidebars)/(feed)/home/page.tsx
+++ b/src/app/(sidebars)/(feed)/home/page.tsx
@@ -1,8 +1,25 @@
 import { PostType, TimelineEventItemType } from "@lens-protocol/client";
 import { fetchPosts, fetchTimeline } from "@lens-protocol/client/actions";
+import type { Metadata } from "next";
 import { Feed } from "~/components/Feed";
 import { lensItemToPost } from "~/components/post/Post";
 import { PostView } from "~/components/post/PostView";
+
+export const metadata: Metadata = {
+  title: "Home",
+  description: "Pingpad feed",
+  openGraph: {
+    title: "Home",
+    description: "Pingpad feed",
+    images: [
+      {
+        url: "/logo.png",
+        width: 1200,
+        height: 630,
+      },
+    ],
+  },
+};
 import { getBaseUrl } from "~/utils/getBaseUrl";
 import { getServerAuth } from "~/utils/getServerAuth";
 
@@ -25,7 +42,7 @@ const getInitialFeed = async () => {
   const { client, isAuthenticated, profileId, address } = await getServerAuth();
 
   try {
-    let data;
+    let data: any;
 
     if (client.isSessionClient()) {
       const result = await fetchTimeline(client, {

--- a/src/app/(sidebars)/(title)/bookmarks/page.tsx
+++ b/src/app/(sidebars)/(title)/bookmarks/page.tsx
@@ -1,8 +1,25 @@
 import { PageSize } from "@lens-protocol/client";
 import { fetchPostBookmarks } from "@lens-protocol/client/actions";
+import type { Metadata } from "next";
 import { Feed } from "~/components/Feed";
 import { lensItemToPost } from "~/components/post/Post";
 import { PostView } from "~/components/post/PostView";
+
+export const metadata: Metadata = {
+  title: "Bookmarks",
+  description: "Your bookmarked posts",
+  openGraph: {
+    title: "Bookmarks",
+    description: "Your bookmarked posts",
+    images: [
+      {
+        url: "/logo.png",
+        width: 1200,
+        height: 630,
+      },
+    ],
+  },
+};
 import { getServerAuth } from "~/utils/getServerAuth";
 
 const endpoint = "/api/bookmarks";

--- a/src/app/(sidebars)/(title)/notifications/page.tsx
+++ b/src/app/(sidebars)/(title)/notifications/page.tsx
@@ -1,8 +1,25 @@
 import { fetchNotifications } from "@lens-protocol/client/actions";
+import type { Metadata } from "next";
 import { Feed } from "~/components/Feed";
 import { lensNotificationToNative } from "~/components/notifications/Notification";
 import { NotificationView } from "~/components/notifications/NotificationView";
 import { getServerAuth } from "~/utils/getServerAuth";
+
+export const metadata: Metadata = {
+  title: "Notifications",
+  description: "Your latest notifications",
+  openGraph: {
+    title: "Notifications",
+    description: "Your latest notifications",
+    images: [
+      {
+        url: "/logo.png",
+        width: 1200,
+        height: 630,
+      },
+    ],
+  },
+};
 
 const endpoint = "/api/notifications";
 

--- a/src/app/(sidebars)/(title)/settings/page.tsx
+++ b/src/app/(sidebars)/(title)/settings/page.tsx
@@ -1,8 +1,25 @@
 import { PawPrintIcon, WalletIcon } from "lucide-react";
+import type { Metadata } from "next";
 import { PingButton } from "~/components/SettingsPageItems";
 import { ThemeButtons } from "~/components/ThemeToggle";
 import { ServerSignedIn } from "~/components/auth/ServerSignedIn";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "~/components/ui/accordion";
+
+export const metadata: Metadata = {
+  title: "Settings",
+  description: "Adjust your preferences",
+  openGraph: {
+    title: "Settings",
+    description: "Adjust your preferences",
+    images: [
+      {
+        url: "/logo.png",
+        width: 1200,
+        height: 630,
+      },
+    ],
+  },
+};
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
 import { Label } from "~/components/ui/label";
 import { ConnectedWalletLabel } from "~/components/web3/ConnnectedWalletLabel";

--- a/src/app/(sidebars)/p/[slug]/page.tsx
+++ b/src/app/(sidebars)/p/[slug]/page.tsx
@@ -27,9 +27,39 @@ export async function generateMetadata({ params }: { params: { slug: string } })
   const title = `${handle}'s post`;
   const ending = content.length > 300 ? "..." : "";
 
+  let image: string | undefined;
+  const metadata = post.metadata as any;
+  switch (metadata?.__typename) {
+    case "ImageMetadata":
+      image = metadata?.image?.item;
+      break;
+    case "VideoMetadata":
+      image = metadata?.video?.cover || metadata?.video?.item;
+      break;
+    case "AudioMetadata":
+      image = metadata?.audio?.cover;
+      break;
+    default:
+      image = undefined;
+  }
+
   return {
     title,
     description: `${content.slice(0, 300)}${ending}`,
+    openGraph: {
+      type: "article",
+      title,
+      description: `${content.slice(0, 300)}${ending}`,
+      images: image
+        ? [
+            {
+              url: image,
+              width: 1200,
+              height: 630,
+            },
+          ]
+        : [],
+    },
   };
 }
 

--- a/src/app/(sidebars)/search/page.tsx
+++ b/src/app/(sidebars)/search/page.tsx
@@ -10,6 +10,17 @@ export async function generateMetadata({ searchParams }: { searchParams: { q: st
   return {
     title,
     description: `@${query} on Pingpad`,
+    openGraph: {
+      title,
+      description: `@${query} on Pingpad`,
+      images: [
+        {
+          url: "/logo.png",
+          width: 1200,
+          height: 630,
+        },
+      ],
+    },
   };
 }
 const search = async () => {

--- a/src/app/(sidebars)/u/[user]/all/page.tsx
+++ b/src/app/(sidebars)/u/[user]/all/page.tsx
@@ -13,6 +13,17 @@ export async function generateMetadata({ params }: { params: { user: string } })
   return {
     title,
     description: `@${handle} on Pingpad`,
+    openGraph: {
+      title,
+      description: `@${handle} on Pingpad`,
+      images: [
+        {
+          url: "/logo.png",
+          width: 1200,
+          height: 630,
+        },
+      ],
+    },
   };
 }
 

--- a/src/app/(sidebars)/u/[user]/comments/page.tsx
+++ b/src/app/(sidebars)/u/[user]/comments/page.tsx
@@ -13,6 +13,17 @@ export async function generateMetadata({ params }: { params: { user: string } })
   return {
     title,
     description: `@${handle}'s comments on Pingpad`,
+    openGraph: {
+      title,
+      description: `@${handle}'s comments on Pingpad`,
+      images: [
+        {
+          url: "/logo.png",
+          width: 1200,
+          height: 630,
+        },
+      ],
+    },
   };
 }
 

--- a/src/app/(sidebars)/u/[user]/gallery/page.tsx
+++ b/src/app/(sidebars)/u/[user]/gallery/page.tsx
@@ -13,6 +13,17 @@ export async function generateMetadata({ params }: { params: { user: string } })
   return {
     title,
     description: `@${handle}'s gallery on Pingpad`,
+    openGraph: {
+      title,
+      description: `@${handle}'s gallery on Pingpad`,
+      images: [
+        {
+          url: "/logo.png",
+          width: 1200,
+          height: 630,
+        },
+      ],
+    },
   };
 }
 

--- a/src/app/(sidebars)/u/[user]/page.tsx
+++ b/src/app/(sidebars)/u/[user]/page.tsx
@@ -10,10 +10,36 @@ import { getUserByUsername } from "~/utils/getUserByHandle";
 
 export async function generateMetadata({ params }: { params: { user: string } }): Promise<Metadata> {
   const handle = params.user;
-  const title = `${handle}`;
+  const user = await getUserByUsername(handle);
+
+  if (!user) {
+    return {
+      title: handle,
+      description: `@${handle} on Pingpad`,
+    };
+  }
+
+  const displayName = user.name || handle;
+  const title = `${displayName} (@${handle})`;
+  const description = user.description || `@${handle} on Pingpad`;
+
   return {
     title,
-    description: `@${handle} on Pingpad`,
+    description,
+    openGraph: {
+      type: "profile",
+      title,
+      description,
+      images: user.profilePictureUrl
+        ? [
+            {
+              url: user.profilePictureUrl,
+              width: 256,
+              height: 256,
+            },
+          ]
+        : [],
+    },
   };
 }
 

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,5 +1,22 @@
 /* eslint-disable react/no-unescaped-entities */
 import { Cookie, FileIcon, Github } from "lucide-react";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "About",
+  description: "About Pingpad",
+  openGraph: {
+    title: "About",
+    description: "About Pingpad",
+    images: [
+      {
+        url: "/logo.png",
+        width: 1200,
+        height: 630,
+      },
+    ],
+  },
+};
 import Link from "~/components/Link";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "~/components/ui/accordion";
 import { Button } from "~/components/ui/button";

--- a/src/app/api/posts/[id]/bookmark/route.ts
+++ b/src/app/api/posts/[id]/bookmark/route.ts
@@ -35,7 +35,7 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
     const bookmarkExists = publication.operations.hasBookmarked;
 
     try {
-      let result;
+      let result: any;
       if (bookmarkExists) {
         result = await undoBookmarkPost(sessionClient, {
           post: publication.id,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,25 @@
 import { AtSign, Github, Heart, InfoIcon, LogInIcon } from "lucide-react";
+import type { Metadata } from "next";
 import { EmailSubscription } from "~/components/EmailSubscription";
 import { LensTextDark, LensTextLight } from "~/components/Icons";
 import Link from "~/components/Link";
 import { ThemeToggle } from "~/components/ThemeToggle";
+
+export const metadata: Metadata = {
+  title: "Pingpad",
+  description: "reach your people on pingpad",
+  openGraph: {
+    title: "Pingpad",
+    description: "reach your people on pingpad",
+    images: [
+      {
+        url: "/logo.png",
+        width: 1200,
+        height: 630,
+      },
+    ],
+  },
+};
 import { FadeIn } from "~/components/Transitions";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "~/components/ui/accordion";
 import { Button } from "~/components/ui/button";
@@ -53,10 +70,7 @@ const LandingPage = () => {
           <FadeIn className="duration-1000 delay-1000">
             <div className="col-span-1 flex flex-row gap-4 items-center justify-center">
               <h1>built on</h1>
-              <Link
-                className="hover:underline -mt-24 -mb-24  flex items-center relative"
-                href={"https://lens.xyz"}
-              >
+              <Link className="hover:underline -mt-24 -mb-24  flex items-center relative" href={"https://lens.xyz"}>
                 <div className="dark:hidden">
                   <LensTextDark />
                 </div>

--- a/src/components/FeedSuspense.tsx
+++ b/src/components/FeedSuspense.tsx
@@ -1,5 +1,6 @@
 import { PostSuspense } from "./post/PostSuspense";
 
 export const FeedSuspense = () => {
+  // biome-ignore lint/suspicious/noArrayIndexKey: stable list
   return [...Array(12)].map((_v, idx) => <PostSuspense key={`suspense-${idx}`} />);
 };

--- a/src/components/ui/carousel.tsx
+++ b/src/components/ui/carousel.tsx
@@ -117,16 +117,15 @@ const Carousel = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivEl
           canScrollNext,
         }}
       >
-        <div
+        <section
           ref={ref}
           onKeyDownCapture={handleKeyDown}
           className={cn("relative", className)}
-          role="region"
           aria-roledescription="carousel"
           {...props}
         >
           {children}
-        </div>
+        </section>
       </CarouselContext.Provider>
     );
   },

--- a/src/utils/clearCookies.ts
+++ b/src/utils/clearCookies.ts
@@ -4,7 +4,7 @@ import { cookies } from "next/headers";
 
 export async function clearCookies() {
   const cookieStore = cookies();
-  cookieStore.getAll().forEach((cookie) => {
+  for (const cookie of cookieStore.getAll()) {
     cookieStore.delete(cookie.name);
-  });
+  }
 }


### PR DESCRIPTION
## Summary
- add OG metadata for user profiles with profile pic
- show attachments as big OG images for posts
- export OG metadata for home, search, policy, tos, about and others
- fix linter errors in feed, cookies, carousel, and post bookmark

## Testing
- `npx @biomejs/biome check --apply-unsafe src`
