### PR TITLE
Implement client-side thread loading

### DIFF
--- a/src/app/(sidebars)/p/[slug]/page.tsx
+++ b/src/app/(sidebars)/p/[slug]/page.tsx
@@ -1,9 +1,8 @@
 import { Post, PostReferenceType } from "@lens-protocol/client";
 import { fetchPost, fetchPostReferences } from "@lens-protocol/client/actions";
 import type { Metadata } from "next";
-import { lensItemToPost } from "~/components/post/Post";
-import { PostView } from "~/components/post/PostView";
-import { Card } from "~/components/ui/card";
+import { type Post as NativePost, lensItemToPost } from "~/components/post/Post";
+import { PostThread } from "~/components/post/PostThread";
 import { getServerAuth } from "~/utils/getServerAuth";
 
 /**
@@ -77,7 +76,6 @@ const post = async ({ params }: { params: { slug: string } }) => {
     });
 
   if (!lensPost) throw new Error("(╥_╥) Post not found");
-  console.log(lensPost);
 
   const lensComments = await fetchPostReferences(client, {
     referenceTypes: [PostReferenceType.CommentOn],
@@ -91,11 +89,7 @@ const post = async ({ params }: { params: { slug: string } }) => {
 
   lensPost.comments = lensComments;
 
-  return (
-    <Card className="z-[30] hover:bg-card p-4 border-0">
-      <PostView item={lensPost} />
-    </Card>
-  );
+  return <PostThread post={lensPost} />;
 };
 
 export default post;

--- a/src/components/post/PostThread.tsx
+++ b/src/components/post/PostThread.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Card } from "../ui/card";
+import type { Post } from "./Post";
+import { PostView } from "./PostView";
+
+export function PostThread({ post }: { post: Post }) {
+  const [thread, setThread] = useState<Post[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function fetchParent(id: string) {
+      try {
+        const res = await fetch(`/api/posts/${id}`);
+        if (!res.ok) throw new Error(res.statusText);
+        const { nativePost } = await res.json();
+        return nativePost as Post;
+      } catch (error) {
+        console.error("Failed to fetch parent post", error);
+        return null;
+      }
+    }
+
+    async function load(current: Post | undefined) {
+      if (!current) return;
+      const parentId = current.commentOn?.id ?? current.quoteOn?.id;
+      if (!parentId) return;
+      const parent = await fetchParent(parentId);
+      if (parent && !cancelled) {
+        setThread((prev) => [parent, ...prev]);
+        await load(parent);
+      }
+    }
+
+    load(post);
+    return () => {
+      cancelled = true;
+    };
+  }, [post.id]);
+
+  return (
+    <div className="flex flex-col gap-4">
+      {thread.map((p) => (
+        <Card key={p.id} className="z-[30] hover:bg-card p-4 border-0">
+          <PostView item={p} />
+        </Card>
+      ))}
+      <Card className="z-[30] hover:bg-card p-4 border-0">
+        <PostView item={post} />
+      </Card>
+    </div>
+  );
+}

--- a/src/components/post/PostView.tsx
+++ b/src/components/post/PostView.tsx
@@ -17,6 +17,7 @@ type PostViewSettings = {
   isComment?: boolean;
   isLastComment?: boolean;
   level?: number;
+  inThread?: boolean;
 };
 
 export const PostView = ({
@@ -55,20 +56,22 @@ export const PostView = ({
         >
           <CardContent className={`flex flex-row p-2 ${settings.isComment ? "sm:p-2 sm:pb-4 gap-2" : "sm:p-4 gap-4 "}`}>
             <span className="min-h-full flex flex-col justify-start items-center relative">
-              <div className={`shrink-0 z-10 grow-0 rounded-full" ${settings.isComment ? "w-6 h-6" : "w-10 h-10"}`}>
+              <div className={`shrink-0 z-20 grow-0 rounded-full" ${settings.isComment ? "w-6 h-6" : "w-10 h-10"}`}>
                 <UserAvatar user={item.author} />
               </div>
-              {settings.isComment && (
+              {(settings.isComment || settings.inThread) && (
                 <div
-                  className={`-mt-4 -mr-6 w-full h-[90%] relative
+                  className={`w-full h-[90%] z-10 relative
                     ${settings.isLastComment && "before:rounded-bl-lg before:border-b before:border-l before:w-[50%]"} 
-                    ${settings.isComment && !settings.isLastComment && "min-h-[calc(100%+2rem)] before:w-[50%]"} 
+                    ${settings.inThread && "-mr-10 -mt-2"} 
+                    ${settings.isComment && "-mr-6 -mt-4 "} 
+                    ${(settings.isComment || settings.inThread) && !settings.isLastComment && "min-h-[calc(100%+2rem)] before:w-[50%]"} 
                     before:absolute before:left-0 before:top-0 before:border-l before:border-border before:h-full`}
                 />
               )}
             </span>
             <div className="flex w-3/4 shrink group max-w-2xl grow flex-col place-content-start">
-              {!settings.isComment && <ReplyInfo post={item} />}
+              {!settings.isComment && !settings.inThread && <ReplyInfo post={item} />}
               <PostInfo post={item} />
               <PostContent ref={postContentRef} post={item} collapsed={collapsed} setCollapsed={setCollapsed} />
               {settings?.showBadges && (


### PR DESCRIPTION
## Summary
- move thread loading into a new client component
- remove accidentally committed `package-lock.json`
- show post thread via `PostThread` after initial render

## Testing
- `npx --no-install biome check --apply-unsafe 'src/app/(sidebars)/p/[slug]/page.tsx' 'src/components/post/PostThread.tsx'`
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_b_683a055e8c58832ebea291c823db88ae