### PR TITLE
Increase Reaction icon size

### DIFF
--- a/src/components/ReactionButton.tsx
+++ b/src/components/ReactionButton.tsx
@@ -23,7 +23,7 @@ export const ReactionButton: React.FC<ReactionButtonProps> = ({
       e.stopPropagation();
       onClick();
     }}
-    className="w-12 border-0 px-0 place-content-center items-center flex flex-row gap-1 h-full hover:bg-transparent text-sm sm:text-base"
+    className="w-14 h-9 border-0 px-0 place-content-center items-center flex flex-row gap-1 hover:bg-transparent text-sm sm:text-base"
     disabled={disabled}
   >
     {reactionType !== "Upvote" && reactionType !== "Downvote" && (

--- a/src/components/ReactionCount.tsx
+++ b/src/components/ReactionCount.tsx
@@ -15,7 +15,9 @@ export const ReactionCount = ({
   }).format(amount);
 
   return (
-    <span className={isPressed ? "font-semibold text-accent-foreground" : ""}>
+    <span
+      className={`inline-flex items-center leading-none ${isPressed ? "font-semibold text-accent-foreground" : ""}`}
+    >
       <span className="w-fit font-medium">{formattedAmount}</span>
     </span>
   );

--- a/src/components/ReactionIcon.tsx
+++ b/src/components/ReactionIcon.tsx
@@ -16,15 +16,15 @@ interface ReactionIconProps {
 }
 
 const ReactionIcon = forwardRef<SVGSVGElement, ReactionIconProps>(({ reaction, pressed }, ref) => {
-  const iconProps = pressed ? { strokeWidth: 3.5, fill: "hsl(var(--primary))" } : { strokeWidth: 1.8 };
+  const iconProps = pressed ? { strokeWidth: 4, fill: "hsl(var(--primary))" } : { strokeWidth: 2.2 };
   const icons = {
-    Like: <HeartIcon size={15} {...iconProps} ref={ref} />,
-    Upvote: <ArrowBigUp size={20} {...iconProps} strokeWidth={1.5} ref={ref} />,
-    Downvote: <ArrowBigDown size={20} {...iconProps} strokeWidth={1.5} ref={ref} />,
-    Bookmark: <BookmarkIcon size={16} {...iconProps} ref={ref} />,
-    Repost: <Repeat2Icon size={18} strokeWidth={pressed ? 3 : 1.5} ref={ref} />,
-    Collect: <CirclePlusIcon size={16} strokeWidth={pressed ? 3.3 : 2} ref={ref} />,
-    Comment: <MessageSquareIcon size={15} ref={ref} />,
+    Like: <HeartIcon size={18} {...iconProps} ref={ref} />,
+    Upvote: <ArrowBigUp size={24} {...iconProps} strokeWidth={1.8} ref={ref} />,
+    Downvote: <ArrowBigDown size={24} {...iconProps} strokeWidth={1.8} ref={ref} />,
+    Bookmark: <BookmarkIcon size={18} {...iconProps} ref={ref} />,
+    Repost: <Repeat2Icon size={20} strokeWidth={pressed ? 3.5 : 2} ref={ref} />,
+    Collect: <CirclePlusIcon size={18} strokeWidth={pressed ? 3.5 : 2.4} ref={ref} />,
+    Comment: <MessageSquareIcon size={18} ref={ref} />,
   };
 
   return icons[reaction] || null;


### PR DESCRIPTION
## Summary
- enlarge reaction buttons
- tweak stroke widths
- keep row height stable

## Testing
- `npx @biomejs/biome check src/components/ReactionButton.tsx src/components/ReactionCount.tsx src/components/ReactionIcon.tsx`

------
https://chatgpt.com/codex/tasks/task_b_683abe1578f0832e8df788838acb8075