### PR TITLE
Improve post menus

### DIFF
--- a/src/components/post/PostInfo.tsx
+++ b/src/components/post/PostInfo.tsx
@@ -1,12 +1,18 @@
-import Link from "~/components/Link";
 import { useState } from "react";
+import Link from "~/components/Link";
 import { TimeElapsedSince } from "../TimeLabel";
 import { Button } from "../ui/button";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from "../ui/dropdown-menu";
 import type { Post } from "./Post";
 import { PostMenu } from "./PostMenu";
 
-export const PostInfo = ({ post }: { post: Post }) => {
+export const PostInfo = ({
+  post,
+  onReply,
+}: {
+  post: Post;
+  onReply?: () => void;
+}) => {
   const [open, setOpen] = useState(false);
   const author = post.author;
   const isGlobalHandle = author.namespace === undefined;
@@ -54,7 +60,7 @@ export const PostInfo = ({ post }: { post: Post }) => {
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent className="flex flex-col w-max gap-1 p-1 hover:bg-card border">
-          <PostMenu post={post} onMenuAction={handleMenuAction} />
+          <PostMenu post={post} onReply={onReply} onMenuAction={handleMenuAction} />
         </DropdownMenuContent>
       </DropdownMenu>
     </div>

--- a/src/components/post/PostView.tsx
+++ b/src/components/post/PostView.tsx
@@ -69,7 +69,7 @@ export const PostView = ({
             </span>
             <div className="flex w-3/4 shrink group max-w-2xl grow flex-col place-content-start">
               {!settings.isComment && !settings.inThread && <ReplyInfo post={item} />}
-              <PostInfo post={item} />
+              <PostInfo post={item} onReply={handleReply} />
               <PostContent ref={postContentRef} post={item} collapsed={collapsed} setCollapsed={setCollapsed} />
               {settings?.showBadges && (
                 <ReactionsList

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -21,7 +21,7 @@ const buttonVariants = cva(
       size: {
         default: "w-fit px-4 py-2",
         sm_icon: "h-10 w-10 sm:w-fit sm:px-4 sm:py-2",
-        context: "rounded-md h-8 w-full px-2 py-2 justify-start text-sm",
+        context: "rounded-md h-7 w-full px-2 py-2 justify-start text-sm",
         sm: "h-9 px-3",
         icon: "h-10 w-10",
         lg: "h-11 rounded-xl px-8",

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -21,7 +21,7 @@ const buttonVariants = cva(
       size: {
         default: "w-fit px-4 py-2",
         sm_icon: "h-10 w-10 sm:w-fit sm:px-4 sm:py-2",
-        context: "h-6 w-full px-2 py-3 justify-start text-sm",
+        context: "rounded-md h-8 w-full px-2 py-2 justify-start text-sm",
         sm: "h-9 px-3",
         icon: "h-10 w-10",
         lg: "h-11 rounded-xl px-8",

--- a/src/components/ui/context-menu.tsx
+++ b/src/components/ui/context-menu.tsx
@@ -46,7 +46,7 @@ const ContextMenuSubContent = React.forwardRef<
   <ContextMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      "z-50 min-w-[10rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
       className,
     )}
     {...props}
@@ -62,7 +62,7 @@ const ContextMenuContent = React.forwardRef<
     <ContextMenuPrimitive.Content
       ref={ref}
       className={cn(
-        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md animate-in fade-in-80 data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "z-50 min-w-[10rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md animate-in fade-in-80 data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className,
       )}
       {...props}


### PR DESCRIPTION
## Summary
- refine context menu styling and width
- allow PostInfo dropdown menu to trigger reply
- adjust PostView usage

## Testing
- `npx @biomejs/biome check --apply-unsafe src/components/post/PostInfo.tsx src/components/post/PostView.tsx src/components/ui/button.tsx src/components/ui/context-menu.tsx`

------
https://chatgpt.com/codex/tasks/task_b_683b4ae17a38832ea85ae3a272c47d78