### PR TITLE
Add gallery suspense

### DIFF
--- a/src/app/(sidebars)/u/[user]/gallery/loading.tsx
+++ b/src/app/(sidebars)/u/[user]/gallery/loading.tsx
@@ -1,0 +1,5 @@
+import { GallerySuspense } from "~/components/GallerySuspense";
+
+export default function loading() {
+  return <GallerySuspense />;
+}

--- a/src/components/GallerySuspense.tsx
+++ b/src/components/GallerySuspense.tsx
@@ -1,0 +1,15 @@
+"use client";
+import { Card } from "./ui/card";
+
+export const GallerySuspense = () => {
+  const placeholders = Array.from({ length: 9 }, () => crypto.randomUUID());
+  return (
+    <div className="grid grid-cols-3 gap-2">
+      {placeholders.map((id) => (
+        <Card key={id} className="overflow-hidden p-0">
+          <div className="aspect-square w-full animate-pulse bg-muted" />
+        </Card>
+      ))}
+    </div>
+  );
+};

--- a/src/components/GallerySuspense.tsx
+++ b/src/components/GallerySuspense.tsx
@@ -7,7 +7,7 @@ export const GallerySuspense = () => {
     <div className="grid grid-cols-3 gap-2">
       {placeholders.map((id) => (
         <Card key={id} className="overflow-hidden p-0">
-          <div className="aspect-square w-full animate-pulse bg-muted" />
+          <div className="aspect-square w-full animate-pulse bg-muted/60" />
         </Card>
       ))}
     </div>


### PR DESCRIPTION
## Summary
- create a `GallerySuspense` component to show loading squares
- add `loading.tsx` for the user gallery route

## Testing
- `npx biome format src/components/GallerySuspense.tsx 'src/app/(sidebars)/u/[user]/gallery/loading.tsx' --write`
- `npx biome lint src/components/GallerySuspense.tsx 'src/app/(sidebars)/u/[user]/gallery/loading.tsx'`
- `npm run check` *(fails: Found 1 error in other files)*

------
https://chatgpt.com/codex/tasks/task_b_683c14e94310832e867613c93a610dd1