### PR TITLE
Add bouncy menu buttons

### DIFF
--- a/src/components/FeedSuspense.tsx
+++ b/src/components/FeedSuspense.tsx
@@ -1,10 +1,6 @@
 import { PostSuspense } from "./post/PostSuspense";
 
 export const FeedSuspense = () => {
-  const items = [...Array(12)].map((_v, idx) => <PostSuspense key={`suspense-${idx}`} />);
-  return (
-    <div className="flex flex-col gap-0.5">
-      {items}
-    </div>
-  );
+  const items = Array.from({ length: 12 }, () => <PostSuspense key={crypto.randomUUID()} />);
+  return <div className="flex flex-col gap-0.5">{items}</div>;
 };

--- a/src/components/menu/Menu.tsx
+++ b/src/components/menu/Menu.tsx
@@ -1,4 +1,5 @@
 import { AtSign, BookmarkIcon, PlusIcon } from "lucide-react";
+import { motion } from "motion/react";
 import Link from "~/components/Link";
 import { Button } from "~/components/ui/button";
 import { getServerAuth } from "~/utils/getServerAuth";
@@ -19,8 +20,14 @@ export default async function Menu() {
     <div className="fixed bottom-0 left-0 w-full p-2 pb-6 sm:bottom-auto sm:top-1/2 sm:right-2 sm:left-auto sm:w-auto sm:-translate-y-1/2 sm:p-2 z-50 bg-background/80 backdrop-blur-md rounded-2xl">
       <div className="flex flex-row sm:flex-col items-center justify-around sm:justify-center gap-6 sm:gap-6">
         <Link href="/home" className="flex-shrink-0">
-          <Button variant="ghost" size="icon" className="w-12 h-12">
-            <AtSign size={20} strokeWidth={2.5} />
+          <Button variant="ghost" size="icon" className="w-12 h-12" asChild>
+            <motion.button
+              whileTap={{ scale: 0.9 }}
+              whileHover={{ scale: 1.1 }}
+              transition={{ type: "spring", bounce: 0.3 }}
+            >
+              <AtSign size={20} strokeWidth={2.5} />
+            </motion.button>
           </Button>
         </Link>
 
@@ -34,10 +41,16 @@ export default async function Menu() {
               <NotificationButton />
             </div>
 
-            <Dialog  modal={true}>
+            <Dialog modal={true}>
               <DialogTrigger asChild>
-                <Button variant="secondary" size="icon" className="w-12 h-12 flex-shrink-0">
-                  <PlusIcon size={20} strokeWidth={2.5} />
+                <Button variant="secondary" size="icon" className="w-12 h-12 flex-shrink-0" asChild>
+                  <motion.button
+                    whileTap={{ scale: 0.9 }}
+                    whileHover={{ scale: 1.1 }}
+                    transition={{ type: "spring", bounce: 0.3 }}
+                  >
+                    <PlusIcon size={20} strokeWidth={2.5} />
+                  </motion.button>
                 </Button>
               </DialogTrigger>
               <DialogContent className="max-w-full sm:max-w-[700px]">
@@ -53,8 +66,14 @@ export default async function Menu() {
             </div>
 
             <Link href="/bookmarks" className="flex-shrink-0">
-              <Button variant="ghost" size="icon" className="w-12 h-12">
-                <BookmarkIcon size={20} strokeWidth={2.5} />
+              <Button variant="ghost" size="icon" className="w-12 h-12" asChild>
+                <motion.button
+                  whileTap={{ scale: 0.9 }}
+                  whileHover={{ scale: 1.1 }}
+                  transition={{ type: "spring", bounce: 0.3 }}
+                >
+                  <BookmarkIcon size={20} strokeWidth={2.5} />
+                </motion.button>
               </Button>
             </Link>
           </ServerSignedIn>

--- a/src/components/menu/UserMenu.tsx
+++ b/src/components/menu/UserMenu.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { LogOutIcon, MoonIcon, SunIcon, UserIcon, UsersIcon } from "lucide-react";
+import { motion } from "motion/react";
 import { useTheme } from "next-themes";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
@@ -50,10 +51,16 @@ export function UserMenu({
     <Dialog onOpenChange={setDialogOpen} open={dialogOpen}>
       <DropdownMenu modal={false}>
         <DropdownMenuTrigger asChild>
-          <Button variant="ghost" size="icon" className="w-12 h-12 p-1.5">
-            <div className="w-8 h-8 rounded-lg overflow-hidden">
-              <UserAvatar link={false} card={false} user={user} />
-            </div>
+          <Button variant="ghost" size="icon" className="w-12 h-12 p-1.5" asChild>
+            <motion.button
+              whileTap={{ scale: 0.9 }}
+              whileHover={{ scale: 1.1 }}
+              transition={{ type: "spring", bounce: 0.3 }}
+            >
+              <div className="w-8 h-8 rounded-lg overflow-hidden">
+                <UserAvatar link={false} card={false} user={user} />
+              </div>
+            </motion.button>
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent className="flex flex-col w-40 gap-1 p-1 border">

--- a/src/components/notifications/NotificationButton.tsx
+++ b/src/components/notifications/NotificationButton.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { BellIcon } from "lucide-react";
+import { motion } from "motion/react";
 import { usePathname } from "next/navigation";
 import Link from "~/components/Link";
 import { useNotifications } from "~/components/notifications/NotificationsContext";
@@ -18,13 +19,19 @@ export const NotificationButton = () => {
 
   return (
     <Link href="/notifications" onClick={handleClick}>
-      <Button variant="ghost" size="icon" className="w-12 h-12 relative">
-        <BellIcon size={20} strokeWidth={2.5} />
-        {newCount > 0 && (
-          <span className="absolute -bottom-1 -right-1 w-4 h-4 rounded-full bg-primary text-primary-foreground text-[10px] flex items-center justify-center">
-            {newCount}
-          </span>
-        )}
+      <Button variant="ghost" size="icon" className="w-12 h-12 relative" asChild>
+        <motion.button
+          whileTap={{ scale: 0.9 }}
+          whileHover={{ scale: 1.1 }}
+          transition={{ type: "spring", bounce: 0.3 }}
+        >
+          <BellIcon size={20} strokeWidth={2.5} />
+          {newCount > 0 && (
+            <span className="absolute -bottom-1 -right-1 w-4 h-4 rounded-full bg-primary text-primary-foreground text-[10px] flex items-center justify-center">
+              {newCount}
+            </span>
+          )}
+        </motion.button>
       </Button>
     </Link>
   );

--- a/src/components/web3/WalletButtons.tsx
+++ b/src/components/web3/WalletButtons.tsx
@@ -1,13 +1,14 @@
 "use client";
 
 import { useLogout } from "@lens-protocol/react";
-import { FamilyIcon, GlobeIcon } from "../Icons";
 import { Grid2X2, LogInIcon, SquareIcon, UserMinusIcon, UsersIcon } from "lucide-react";
+import { motion } from "motion/react";
 import { useRouter } from "next/navigation";
 import { type PropsWithChildren, useState } from "react";
 import { toast } from "sonner";
 import { useAccount, useConnect, useDisconnect } from "wagmi";
 import { clearCookies } from "../../utils/clearCookies";
+import { FamilyIcon, GlobeIcon } from "../Icons";
 import { WalletConnectIcon } from "../Icons";
 import { Button } from "../ui/button";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from "../ui/dialog";
@@ -71,8 +72,14 @@ export function ConnectWalletButton() {
   return (
     <Dialog onOpenChange={(open) => setDialogOpen(open)} open={dialogOpen}>
       <DialogTrigger asChild>
-        <Button size="sm" className="w-12 h-12" onClick={(_e) => setDialogOpen(true)}>
-          <LogInIcon size={20} strokeWidth={2.5} />
+        <Button size="sm" className="w-12 h-12" onClick={(_e) => setDialogOpen(true)} asChild>
+          <motion.button
+            whileTap={{ scale: 0.9 }}
+            whileHover={{ scale: 1.1 }}
+            transition={{ type: "spring", bounce: 0.3 }}
+          >
+            <LogInIcon size={20} strokeWidth={2.5} />
+          </motion.button>
         </Button>
       </DialogTrigger>
       <DialogContent className="max-w-sm flex flex-col justify-center">


### PR DESCRIPTION
## Summary
- make menu buttons bouncy
- add bounce animation to user menu trigger
- animate notification button
- bounce connect wallet button
- fix FeedSuspense keys

## Testing
- `npx biome check src/components/FeedSuspense.tsx src/components/menu/Menu.tsx src/components/menu/UserMenu.tsx src/components/notifications/NotificationButton.tsx src/components/web3/WalletButtons.tsx`

------
https://chatgpt.com/codex/tasks/task_b_683c2bff0f5c832e8eb9d4b1c546fb3d