### PR TITLE
Add bounce animation to menu buttons

### DIFF
--- a/src/components/menu/Menu.tsx
+++ b/src/components/menu/Menu.tsx
@@ -19,7 +19,7 @@ export default async function Menu() {
     <div className="fixed bottom-0 left-0 w-full p-2 pb-6 sm:bottom-auto sm:top-1/2 sm:right-2 sm:left-auto sm:w-auto sm:-translate-y-1/2 sm:p-2 z-50 bg-background/80 backdrop-blur-md rounded-2xl">
       <div className="flex flex-row sm:flex-col items-center justify-around sm:justify-center gap-6 sm:gap-6">
         <Link href="/home" className="flex-shrink-0">
-          <Button variant="ghost" size="icon" className="w-12 h-12">
+          <Button variant="ghost" size="icon" className="w-12 h-12 transition hover:animate-bounce">
             <AtSign size={20} strokeWidth={2.5} />
           </Button>
         </Link>
@@ -34,9 +34,13 @@ export default async function Menu() {
               <NotificationButton />
             </div>
 
-            <Dialog  modal={true}>
+            <Dialog modal={true}>
               <DialogTrigger asChild>
-                <Button variant="secondary" size="icon" className="w-12 h-12 flex-shrink-0">
+                <Button
+                  variant="secondary"
+                  size="icon"
+                  className="w-12 h-12 flex-shrink-0 transition hover:animate-bounce"
+                >
                   <PlusIcon size={20} strokeWidth={2.5} />
                 </Button>
               </DialogTrigger>
@@ -53,7 +57,7 @@ export default async function Menu() {
             </div>
 
             <Link href="/bookmarks" className="flex-shrink-0">
-              <Button variant="ghost" size="icon" className="w-12 h-12">
+              <Button variant="ghost" size="icon" className="w-12 h-12 transition hover:animate-bounce">
                 <BookmarkIcon size={20} strokeWidth={2.5} />
               </Button>
             </Link>

--- a/src/components/menu/UserMenu.tsx
+++ b/src/components/menu/UserMenu.tsx
@@ -50,7 +50,7 @@ export function UserMenu({
     <Dialog onOpenChange={setDialogOpen} open={dialogOpen}>
       <DropdownMenu modal={false}>
         <DropdownMenuTrigger asChild>
-          <Button variant="ghost" size="icon" className="w-12 h-12 p-1.5">
+          <Button variant="ghost" size="icon" className="w-12 h-12 p-1.5 transition hover:animate-bounce">
             <div className="w-8 h-8 rounded-lg overflow-hidden">
               <UserAvatar link={false} card={false} user={user} />
             </div>

--- a/src/components/notifications/NotificationButton.tsx
+++ b/src/components/notifications/NotificationButton.tsx
@@ -18,7 +18,7 @@ export const NotificationButton = () => {
 
   return (
     <Link href="/notifications" onClick={handleClick}>
-      <Button variant="ghost" size="icon" className="w-12 h-12 relative">
+      <Button variant="ghost" size="icon" className={`w-12 h-12 relative ${newCount > 0 ? "animate-bounce" : ""}`}>
         <BellIcon size={20} strokeWidth={2.5} />
         {newCount > 0 && (
           <span className="absolute -bottom-1 -right-1 w-4 h-4 rounded-full bg-primary text-primary-foreground text-[10px] flex items-center justify-center">


### PR DESCRIPTION
## Summary
- make home, compose and bookmark buttons bounce on hover
- animate user menu trigger on hover
- animate notification button when notifications are unread

## Testing
- `npx @biomejs/biome check src/components/menu/Menu.tsx src/components/menu/UserMenu.tsx src/components/notifications/NotificationButton.tsx --apply-unsafe`

------
https://chatgpt.com/codex/tasks/task_b_683c40f89138832ebec7000d0cea01a4