### PR TITLE
Fix markdown image rendering

### DIFF
--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -4,12 +4,13 @@ import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
 import { getBaseUrl } from "~/utils/getBaseUrl";
 import { parseContent } from "~/utils/parseContent";
+import { ImageViewer } from "./ImageViewer";
 import { CommunityHandle } from "./communities/CommunityHandle";
 import { UserLazyHandle } from "./user/UserLazyHandle";
 
 const BASE_URL = getBaseUrl();
 const Markdown: React.FC<{ content: string }> = ({ content }) => {
-  const processedText = parseContent(content).replaceHandles().parseLinks().toString();
+  const processedText = parseContent(content).replaceHandles().parseLinks().parseImages().toString();
   return (
     <ReactMarkdown
       className="prose dark:prose-invert prose-p:m-0 prose-p:inline
@@ -19,6 +20,7 @@ const Markdown: React.FC<{ content: string }> = ({ content }) => {
       components={{
         h1: "h2",
         a: CustomLink,
+        img: CustomImage,
       }}
     >
       {processedText}
@@ -37,6 +39,12 @@ const CustomLink: Components["a"] = ({ node, ...props }) => {
     }
   }
   return <a {...props}>{children}</a>;
+};
+
+const CustomImage: Components["img"] = ({ node, ...props }) => {
+  const { src, alt } = props;
+  if (!src) return null;
+  return <ImageViewer src={src} alt={alt} className="rounded-lg" />;
 };
 
 export default Markdown;

--- a/src/utils/parseContent.ts
+++ b/src/utils/parseContent.ts
@@ -32,6 +32,21 @@ class ContentParser {
     return this;
   }
 
+  parseImages(): ContentParser {
+    const imageLinkRegex = /\[([^\]]+)\]\(((?:https?:\/\/|www\.)[^)\s]+)\)/g;
+    this.content = this.content.replace(imageLinkRegex, (match, text, url) => {
+      const normalizedUrl = url.startsWith("http") ? url : `https://${url}`;
+      const urlWithoutProtocol = normalizedUrl.replace(/^https?:\/\//, "");
+      const isAutoLink = text === urlWithoutProtocol;
+      const isImage = /\.(png|jpe?g|gif|webp|svg)$/i.test(normalizedUrl) || normalizedUrl.includes("api.grove.storage");
+      if (isAutoLink && isImage) {
+        return `![${text}](${normalizedUrl})`;
+      }
+      return match;
+    });
+    return this;
+  }
+
   toString(): string {
     return this.content;
   }


### PR DESCRIPTION
## Summary
- convert bare image links to images in Markdown parser
- display images using `ImageViewer` component

## Testing
- `npx @biomejs/biome check --apply-unsafe src/components/Markdown.tsx src/utils/parseContent.ts`
- `npm run build` *(fails: FetchError: Failed to fetch Quicksand from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_b_683c8ff287b8832eba3ec8c539f54ff2