### PR TITLE
Fix explosion overlay depth

### DIFF
--- a/src/components/menu/UserMenu.tsx
+++ b/src/components/menu/UserMenu.tsx
@@ -171,12 +171,16 @@ export function UserMenuButtons({ handle, user }: { handle: string; user: User }
     <>
       <div className="flex flex-col w-40 gap-1 p-1">
         <Link href={`/u/${handle}`}>
-          <button className="flex gap-2 items-center w-full px-3 py-2 text-sm rounded-md hover:bg-secondary transition-colors">
+          <button
+            type="button"
+            className="flex gap-2 items-center w-full px-3 py-2 text-sm rounded-md hover:bg-secondary transition-colors"
+          >
             <UserIcon size={16} />
             Profile
           </button>
         </Link>
         <button
+          type="button"
           className="flex gap-2 items-center w-full px-3 py-2 text-sm rounded-md hover:bg-secondary transition-colors"
           onClick={() => setDialogOpen(true)}
         >
@@ -184,12 +188,16 @@ export function UserMenuButtons({ handle, user }: { handle: string; user: User }
           Switch Profile
         </button>
         <Link href="/settings">
-          <button className="flex gap-2 items-center w-full px-3 py-2 text-sm rounded-md hover:bg-secondary transition-colors">
+          <button
+            type="button"
+            className="flex gap-2 items-center w-full px-3 py-2 text-sm rounded-md hover:bg-secondary transition-colors"
+          >
             <SettingsIcon size={16} />
             Settings
           </button>
         </Link>
         <button
+          type="button"
           className="flex gap-2 items-center w-full px-3 py-2 text-sm rounded-md hover:bg-secondary transition-colors"
           onClick={toggleTheme}
         >
@@ -197,6 +205,7 @@ export function UserMenuButtons({ handle, user }: { handle: string; user: User }
           Toggle Theme
         </button>
         <button
+          type="button"
           className="flex gap-2 items-center w-full px-3 py-2 text-sm rounded-md hover:bg-secondary transition-colors"
           onClick={logout}
         >

--- a/src/components/post/PostReactions.tsx
+++ b/src/components/post/PostReactions.tsx
@@ -156,7 +156,7 @@ export function ReactionsList({
         )}
         <Explosion
           onInit={onInitHandler}
-          className="absolute left-[50%] top-[50%] translate-x-[-50%] translate-y-[-50%] z-[30] select-none pointer-events-none"
+          className="absolute left-[50%] top-[50%] translate-x-[-50%] translate-y-[-50%] z-[50] select-none pointer-events-none"
           width={400}
           height={400}
           globalOptions={{ useWorker: true, disableForReducedMotion: true, resize: true }}


### PR DESCRIPTION
## Summary
- bump explosion canvas z-index so confetti stays above posts
- add explicit button types in user menu

## Testing
- `npm run check`
- `npx biome check src/components/post/PostReactions.tsx src/components/menu/UserMenu.tsx`

------
https://chatgpt.com/codex/tasks/task_b_68401269812c832e8a15abf8d412b0c7