### PR TITLE
Add self-thread loading in PostView

### DIFF
--- a/src/app/api/posts/[id]/thread/route.ts
+++ b/src/app/api/posts/[id]/thread/route.ts
@@ -1,0 +1,85 @@
+import { PostReferenceType } from "@lens-protocol/client";
+import { fetchPost, fetchPostReferences } from "@lens-protocol/client/actions";
+import { PageSize } from "@lens-protocol/react";
+import { type NextRequest, NextResponse } from "next/server";
+import { lensItemToPost } from "~/components/post/Post";
+import { getServerAuth } from "~/utils/getServerAuth";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  const id = params.id;
+  const depthParam = req.nextUrl.searchParams.get("depth");
+  const maxDepth = depthParam ? Number(depthParam) : Number.POSITIVE_INFINITY;
+
+  if (!id) {
+    return NextResponse.json({ error: "Missing publication id" }, { status: 400 });
+  }
+
+  try {
+    const { client } = await getServerAuth();
+
+    const startResult = await fetchPost(client, { post: id });
+    if (startResult.isErr()) {
+      return NextResponse.json({ error: "Failed to fetch post" }, { status: 500 });
+    }
+
+    const startPost = lensItemToPost(startResult.value);
+    if (!startPost) {
+      return NextResponse.json({ error: "Post not found" }, { status: 404 });
+    }
+
+    let rootId = startPost.id;
+    let parentId = startPost.commentOn?.id ?? startPost.quoteOn?.id;
+    while (parentId) {
+      const parentRes = await fetchPost(client, { post: parentId });
+      if (parentRes.isErr()) break;
+      const parent = lensItemToPost(parentRes.value);
+      if (!parent) break;
+      rootId = parent.id;
+      parentId = parent.commentOn?.id ?? parent.quoteOn?.id;
+    }
+
+    const thread: any[] = [];
+    let current = startPost;
+    let hasMore = false;
+    let depth = 0;
+
+    while (depth !== maxDepth) {
+      const references = await fetchPostReferences(client, {
+        referenceTypes: [PostReferenceType.CommentOn],
+        referencedPost: current.id,
+        pageSize: PageSize.Ten,
+      });
+
+      if (references.isErr()) break;
+      const items = references.value.items.map((item) => lensItemToPost(item));
+      const next = items.find((p) => p?.author.address === startPost.author.address);
+      if (!next) break;
+      thread.push(next);
+      current = next;
+      depth += 1;
+    }
+
+    // check if there are more posts beyond the limit
+    if (maxDepth !== Number.POSITIVE_INFINITY) {
+      const references = await fetchPostReferences(client, {
+        referenceTypes: [PostReferenceType.CommentOn],
+        referencedPost: current.id,
+        pageSize: PageSize.Ten,
+      });
+      if (references.isOk()) {
+        const items = references.value.items.map((item) => lensItemToPost(item));
+        const next = items.find((p) => p?.author.address === startPost.author.address);
+        if (next) {
+          hasMore = true;
+        }
+      }
+    }
+
+    return NextResponse.json({ thread, rootId, hasMore }, { status: 200 });
+  } catch (error: any) {
+    console.error("Failed to load thread: ", error);
+    return NextResponse.json({ error: `Failed to load thread: ${error.message}` }, { status: 500 });
+  }
+}

--- a/src/components/menu/UserMenu.tsx
+++ b/src/components/menu/UserMenu.tsx
@@ -171,7 +171,10 @@ export function UserMenuButtons({ handle, user }: { handle: string; user: User }
     <>
       <div className="flex flex-col w-40 gap-1 p-1">
         <Link href={`/u/${handle}`}>
-          <button className="flex gap-2 items-center w-full px-3 py-2 text-sm rounded-md hover:bg-secondary transition-colors">
+          <button
+            type="button"
+            className="flex gap-2 items-center w-full px-3 py-2 text-sm rounded-md hover:bg-secondary transition-colors"
+          >
             <UserIcon size={16} />
             Profile
           </button>
@@ -179,12 +182,16 @@ export function UserMenuButtons({ handle, user }: { handle: string; user: User }
         <button
           className="flex gap-2 items-center w-full px-3 py-2 text-sm rounded-md hover:bg-secondary transition-colors"
           onClick={() => setDialogOpen(true)}
+          type="button"
         >
           <UsersIcon size={16} />
           Switch Profile
         </button>
         <Link href="/settings">
-          <button className="flex gap-2 items-center w-full px-3 py-2 text-sm rounded-md hover:bg-secondary transition-colors">
+          <button
+            type="button"
+            className="flex gap-2 items-center w-full px-3 py-2 text-sm rounded-md hover:bg-secondary transition-colors"
+          >
             <SettingsIcon size={16} />
             Settings
           </button>
@@ -192,6 +199,7 @@ export function UserMenuButtons({ handle, user }: { handle: string; user: User }
         <button
           className="flex gap-2 items-center w-full px-3 py-2 text-sm rounded-md hover:bg-secondary transition-colors"
           onClick={toggleTheme}
+          type="button"
         >
           {theme === "light" ? <SunIcon size={16} /> : <MoonIcon size={16} />}
           Toggle Theme
@@ -199,6 +207,7 @@ export function UserMenuButtons({ handle, user }: { handle: string; user: User }
         <button
           className="flex gap-2 items-center w-full px-3 py-2 text-sm rounded-md hover:bg-secondary transition-colors"
           onClick={logout}
+          type="button"
         >
           <LogOutIcon size={16} />
           Log out

--- a/src/components/post/PostSelfThread.tsx
+++ b/src/components/post/PostSelfThread.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "../Link";
+import { Button } from "../ui/button";
+import type { Post } from "./Post";
+import { PostView } from "./PostView";
+
+export function PostSelfThread({ post, depth = 3 }: { post: Post; depth?: number }) {
+  const [thread, setThread] = useState<Post[]>([]);
+  const [rootId, setRootId] = useState<string | null>(null);
+  const [hasMore, setHasMore] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      try {
+        const param = depth === Number.POSITIVE_INFINITY ? "" : `?depth=${depth}`;
+        const res = await fetch(`/api/posts/${post.id}/thread${param}`);
+        if (!res.ok) throw new Error(res.statusText);
+        const data = await res.json();
+        if (!cancelled) {
+          setThread(data.thread || []);
+          setRootId(data.rootId);
+          setHasMore(data.hasMore);
+        }
+      } catch (error) {
+        console.error("Failed to load thread", error);
+      }
+    }
+    if (depth !== 0) load();
+    return () => {
+      cancelled = true;
+    };
+  }, [post.id, depth]);
+
+  if (thread.length === 0) return null;
+
+  return (
+    <div className="flex flex-col gap-2 pl-8 mt-2">
+      {thread.map((p) => (
+        <PostView key={p.id} item={p} settings={{ inThread: true }} threadDepth={0} />
+      ))}
+      {hasMore && rootId && (
+        <Link href={`/p/${rootId}`} className="w-full">
+          <Button variant="outline" className="w-full">
+            go to thread
+          </Button>
+        </Link>
+      )}
+    </div>
+  );
+}

--- a/src/components/post/PostThread.tsx
+++ b/src/components/post/PostThread.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { Post } from "./Post";
 import { PostView } from "./PostView";
 
@@ -38,12 +38,12 @@ export function PostThread({ post }: { post: Post }) {
         setThread((prev) => {
           requestAnimationFrame(() => {
             const newContainerTop = containerRef.current?.getBoundingClientRect().top || 0;
-            const heightDifference = (currentScrollY + containerTop) - (currentScrollY + newContainerTop);
+            const heightDifference = currentScrollY + containerTop - (currentScrollY + newContainerTop);
 
             if (heightDifference > 0) {
               window.scrollTo({
                 top: currentScrollY + heightDifference,
-                behavior: 'instant'
+                behavior: "instant",
               });
             }
           });
@@ -64,12 +64,12 @@ export function PostThread({ post }: { post: Post }) {
     <div ref={containerRef} className="flex flex-col">
       {thread.map((p) => (
         <div key={p.id} className="relative">
-          <PostView settings={{ inThread: true }} item={p} />
+          <PostView settings={{ inThread: true }} item={p} threadDepth={Number.POSITIVE_INFINITY} />
         </div>
       ))}
 
       <div className="relative min-h-screen">
-        <PostView item={post} />
+        <PostView item={post} threadDepth={Number.POSITIVE_INFINITY} />
       </div>
     </div>
   );

--- a/src/components/post/PostView.tsx
+++ b/src/components/post/PostView.tsx
@@ -11,6 +11,7 @@ import { PostInfo } from "./PostInfo";
 import { ReactionsList } from "./PostReactions";
 import { ReplyInfo } from "./PostReplyInfo";
 import { PostReplyWizard } from "./PostReplyWizard";
+import { PostSelfThread } from "./PostSelfThread";
 
 type PostViewSettings = {
   showBadges?: boolean;
@@ -24,7 +25,13 @@ export const PostView = ({
   item,
   settings = { isComment: false, showBadges: true, level: 1 },
   defaultReplyOpen = false,
-}: { item: Post; settings?: PostViewSettings; defaultReplyOpen?: boolean }) => {
+  threadDepth = 3,
+}: {
+  item: Post;
+  settings?: PostViewSettings;
+  defaultReplyOpen?: boolean;
+  threadDepth?: number;
+}) => {
   const content = "content" in item.metadata ? (item.metadata.content as string) : "";
   const [collapsed, setCollapsed] = useState(content.length > 400);
   const [isCommentsOpen, setCommentsOpen] = useState(false);
@@ -93,6 +100,7 @@ export const PostView = ({
           setOpen={setReplyWizardOpen}
         />
       )}
+      {threadDepth !== 0 && <PostSelfThread post={item} depth={threadDepth} />}
       {isCommentsOpen && (
         <PostComments
           level={settings.level + 1}


### PR DESCRIPTION
## Summary
- fetch author reply chain in `/api/posts/[id]/thread`
- show post reply chain with `PostSelfThread` component
- allow `PostView` to render self-thread
- load full chains on post page
- fix button types in `UserMenu`

## Testing
- `npx biome check --apply-unsafe ./src/*`
- `npm run build` *(fails: Failed to fetch font `Quicksand`)*

------
https://chatgpt.com/codex/tasks/task_b_68407d7c1ed0832ebb388ebdc54f4e3c