### PR TITLE
fix: making <Avatar/> respect the original proportions of the pfp, in case it's not a squared one

### DIFF
--- a/src/components/user/UserAvatar.tsx
+++ b/src/components/user/UserAvatar.tsx
@@ -7,7 +7,7 @@ export function UserAvatar({ user, link = true, card = true }: { user: User; lin
   const fallback = user?.name?.slice(0, 2) ?? user?.handle?.slice(0, 2) ?? "";
   const avatar = (
     <Avatar suppressHydrationWarning className="w-full h-full m-0">
-      <AvatarImage alt={user?.profilePictureUrl} src={user?.profilePictureUrl} className="m-0" />
+      <AvatarImage alt={user?.profilePictureUrl} src={user?.profilePictureUrl} className="m-0 object-cover" />
       <AvatarFallback>{fallback.toLowerCase()}</AvatarFallback>
     </Avatar>
   );


### PR DESCRIPTION
I'm not sure why, but some Lens profiles have a non-squared profile picture.

This tiny change makes the `<Avatar/>` component keep the image proportions

![image](https://github.com/user-attachments/assets/b6159ba6-2ac2-4535-aa73-efa6d577cd5c)
