### PR TITLE
fix quote posts losing media when text is included

### DIFF
--- a/src/app/api/posts/[id]/quote/route.ts
+++ b/src/app/api/posts/[id]/quote/route.ts
@@ -1,9 +1,7 @@
 import { postId } from "@lens-protocol/client";
 import { post as createPost, fetchPost } from "@lens-protocol/client/actions";
-import { textOnly } from "@lens-protocol/metadata";
 import { type NextRequest, NextResponse } from "next/server";
 import { getServerAuth } from "~/utils/getServerAuth";
-import { uploadMetadata } from "~/utils/uploadMetadata";
 
 export const dynamic = "force-dynamic";
 
@@ -13,10 +11,10 @@ export async function POST(request: NextRequest, context: { params: Promise<{ id
     const { id } = await context.params;
 
     const body = await request.json();
-    const { content } = body;
+    const { contentUri } = body;
 
-    if (!content || typeof content !== "string") {
-      return NextResponse.json({ error: "Content is required" }, { status: 400 });
+    if (!contentUri || typeof contentUri !== "string") {
+      return NextResponse.json({ error: "ContentUri is required" }, { status: 400 });
     }
 
     const targetPostResult = await fetchPost(client, { post: postId(id) });
@@ -33,11 +31,8 @@ export async function POST(request: NextRequest, context: { params: Promise<{ id
       return NextResponse.json({ error: "You cannot quote this post" }, { status: 403 });
     }
 
-    const metadata = textOnly({ content });
-    const metadataUri = await uploadMetadata(metadata);
-
     const result = await createPost(sessionClient, {
-      contentUri: metadataUri,
+      contentUri: contentUri,
       quoteOf: {
         post: postId(id),
       },

--- a/src/hooks/usePostSubmission.ts
+++ b/src/hooks/usePostSubmission.ts
@@ -205,7 +205,7 @@ export function usePostSubmission() {
             const response = await fetch(`/api/posts/${quotedPost.id}/quote`, {
               method: "POST",
               headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({ content }),
+              body: JSON.stringify({ contentUri }),
             });
 
             if (response.ok) {


### PR DESCRIPTION
The fix addresses the issue where quote posts would lose their media when text was included.

The problem was that the quote API endpoint was creating text-only metadata instead of using the already-uploaded metadata that includes images.

Now it properly preserves all media attachments when quoting posts.