### PR TITLE
feat: add share dialog with social platform options

### DIFF
--- a/src/components/post/PostInfo.tsx
+++ b/src/components/post/PostInfo.tsx
@@ -48,7 +48,7 @@ export const PostInfo = ({ post, onReply }: { post: Post; onReply?: () => void }
       name: "Farcaster",
       icon: <SiFarcaster className="w-4 h-4" />,
       getShareUrl: (url: string, title?: string) => {
-        const text = title ? `${title}\n\n${url}` : url;
+        const text = title && title.trim() ? `${title.trim()}\n\n${url}` : url;
         return `https://warpcast.com/~/compose?text=${encodeURIComponent(text)}`;
       },
     },
@@ -65,16 +65,18 @@ export const PostInfo = ({ post, onReply }: { post: Post; onReply?: () => void }
           <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
         </svg>
       ),
-      getShareUrl: (url: string, title?: string) =>
-        `https://twitter.com/intent/tweet?url=${encodeURIComponent(url)}${
-          title ? `&text=${encodeURIComponent(title)}` : ""
-        }`,
+      getShareUrl: (url: string, title?: string) => {
+        // Twitter includes both text and URL in the same parameter for better control
+        const text = title && title.trim() ? `${title.trim()} | ${url}` : url;
+        return `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}`;
+      },
     },
     {
       name: "Bluesky",
       icon: <RiBlueskyLine className="w-4 h-4" />,
       getShareUrl: (url: string, title?: string) => {
-        const text = title ? `${title}\n\n${url}` : url;
+        // Bluesky seems to strip newlines, so we'll use a separator
+        const text = title && title.trim() ? `${title.trim()} | ${url}` : url;
         return `https://bsky.app/intent/compose?text=${encodeURIComponent(text)}`;
       },
     },

--- a/src/components/post/PostInfo.tsx
+++ b/src/components/post/PostInfo.tsx
@@ -1,7 +1,7 @@
 import { Check, Copy, EllipsisIcon, Link2, PenIcon } from "lucide-react";
 import { useState } from "react";
 import { RiBlueskyLine } from "react-icons/ri";
-import { SiFarcaster } from "react-icons/si";
+import { SiFarcaster, SiX } from "react-icons/si";
 import { toast } from "sonner";
 import Link from "~/components/Link";
 import { useUser } from "~/components/user/UserContext";
@@ -54,17 +54,7 @@ export const PostInfo = ({ post, onReply }: { post: Post; onReply?: () => void }
     },
     {
       name: "Twitter",
-      icon: (
-        <svg
-          width="16"
-          height="16"
-          viewBox="0 0 24 24"
-          fill="currentColor"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
-        </svg>
-      ),
+      icon: <SiX className="w-4 h-4" />,
       getShareUrl: (url: string, title?: string) => {
         // Twitter includes both text and URL in the same parameter for better control
         const text = title && title.trim() ? `${title.trim()} | ${url}` : url;

--- a/src/components/post/PostInfo.tsx
+++ b/src/components/post/PostInfo.tsx
@@ -1,22 +1,84 @@
-import { EllipsisIcon, PenIcon } from "lucide-react";
+import { Check, Copy, EllipsisIcon, Link2, PenIcon } from "lucide-react";
 import { useState } from "react";
+import { RiBlueskyLine } from "react-icons/ri";
+import { SiFarcaster } from "react-icons/si";
+import { toast } from "sonner";
 import Link from "~/components/Link";
 import { useUser } from "~/components/user/UserContext";
 import type { Post } from "~/lib/types/post";
 import { TimeElapsedSince } from "../TimeLabel";
 import { Button } from "../ui/button";
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "../ui/dropdown-menu";
+import { GlassEffect } from "../ui/glass-effect";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from "../ui/dropdown-menu";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "../ui/tooltip";
 import { menuItems } from "./PostMenuConfig";
 import { usePostStateContext } from "./PostStateContext";
 
 export const PostInfo = ({ post, onReply }: { post: Post; onReply?: () => void }) => {
   const [open, setOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
   const { requireAuth } = useUser();
   const { shouldShowItem, getItemProps, postLink, isSaved } = usePostStateContext();
   const author = post.author;
   const handle = author.username;
   const tags = post?.metadata?.tags || [];
+  const content = "content" in post.metadata ? (post.metadata.content as string) : "";
+
+  const handleCopyLink = async () => {
+    try {
+      await navigator.clipboard.writeText(postLink);
+      setCopied(true);
+      toast.success("Link copied to clipboard");
+      setTimeout(() => setCopied(false), 2000);
+    } catch (error) {
+      toast.error("Failed to copy link");
+    }
+  };
+
+  const sharePlatforms = [
+    {
+      name: "Farcaster",
+      icon: <SiFarcaster className="w-4 h-4" />,
+      getShareUrl: (url: string, title?: string) => {
+        const text = title ? `${title}\n\n${url}` : url;
+        return `https://warpcast.com/~/compose?text=${encodeURIComponent(text)}`;
+      },
+    },
+    {
+      name: "Twitter",
+      icon: (
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+        </svg>
+      ),
+      getShareUrl: (url: string, title?: string) =>
+        `https://twitter.com/intent/tweet?url=${encodeURIComponent(url)}${
+          title ? `&text=${encodeURIComponent(title)}` : ""
+        }`,
+    },
+    {
+      name: "Bluesky",
+      icon: <RiBlueskyLine className="w-4 h-4" />,
+      getShareUrl: (url: string, title?: string) => {
+        const text = title ? `${title}\n\n${url}` : url;
+        return `https://bsky.app/intent/compose?text=${encodeURIComponent(text)}`;
+      },
+    },
+  ];
 
   let community = null;
   tags.map((tag: string) => {
@@ -99,6 +161,52 @@ export const PostInfo = ({ post, onReply }: { post: Post; onReply?: () => void }
                       {itemProps.label}
                     </Link>
                   </DropdownMenuItem>
+                );
+              }
+
+              if (item.id === "share") {
+                return (
+                  <DropdownMenuSub key={item.id}>
+                    <DropdownMenuSubTrigger className="flex items-center gap-3">
+                      <div className="flex items-center gap-3">
+                        <Icon size={16} />
+                        <span>{itemProps.label}</span>
+                      </div>
+                    </DropdownMenuSubTrigger>
+                    <DropdownMenuSubContent className="w-48 glass" sideOffset={2} alignOffset={-5}>
+                      {sharePlatforms.map((platform) => (
+                        <DropdownMenuItem
+                          key={platform.name}
+                          onClick={(e) => {
+                            e.preventDefault();
+                            const shareUrl = platform.getShareUrl(postLink, content);
+                            window.open(shareUrl, "_blank");
+                            setOpen(false);
+                          }}
+                          className="flex items-center gap-3"
+                        >
+                          {platform.icon}
+                          {platform.name}
+                        </DropdownMenuItem>
+                      ))}
+                      <DropdownMenuItem
+                        onClick={handleCopyLink}
+                        className="flex items-center gap-3"
+                      >
+                        {copied ? (
+                          <>
+                            <Check className="h-4 w-4" />
+                            Copied!
+                          </>
+                        ) : (
+                          <>
+                            <Link2 className="h-4 w-4" />
+                            Copy link
+                          </>
+                        )}
+                      </DropdownMenuItem>
+                    </DropdownMenuSubContent>
+                  </DropdownMenuSub>
                 );
               }
 

--- a/src/hooks/usePostState.tsx
+++ b/src/hooks/usePostState.tsx
@@ -72,14 +72,7 @@ export const usePostState = (
   };
 
   const share = () => {
-    navigator.clipboard.writeText(shareLink).then(
-      () => {
-        toast.success("Copied link to clipboard");
-      },
-      () => {
-        toast.error("Error copying link to clipboard!");
-      },
-    );
+    // Share functionality is now handled in PostInfo.tsx as a submenu
     onMenuAction?.();
   };
 


### PR DESCRIPTION
Fixes #154

## Summary
Added a share submenu to the post dropdown menu with options to share to Farcaster, Twitter/X, and Bluesky, plus a copy link option.

## Changes
- Implemented share submenu in PostInfo component
- Added support for Farcaster, Twitter/X, and Bluesky sharing
- Used official react-icons (SiFarcaster, RiBlueskyLine)
- Applied glass effect styling to match existing UI
- Added proper content formatting with pipe separator